### PR TITLE
Remove doppelganger

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
       FEE_RECIPIENT_ADDRESS: ""
-      DOPPELGANGER_PROTECTION: "true"
+      DOPPELGANGER_PROTECTION: "false"
 volumes:
   beacon-data: {}
   validator-data: {}


### PR DESCRIPTION
Doppelganger for Lodestar in Holesky network is causing the validator service to miss attestations:

```
Nov-13 11:47:12.941[]                error: Error getting liveness data for epoch 10346 - Bad Request: Request epoch 10346 is more than one epoch before or after the current epoch 10348
Error: Bad Request: Request epoch 10346 is more than one epoch before or after the current epoch 10348
    at DoppelgangerService.getLiveness (file:///usr/app/packages/validator/src/services/doppelgangerService.ts:178:9)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
    at DoppelgangerService.pollLiveness (file:///usr/app/packages/validator/src/services/doppelgangerService.ts:160:33)
    at Clock.runAtMostEvery (file:///usr/app/packages/validator/src/util/clock.ts:96:7)
```